### PR TITLE
Bugfix: Fix incorrect Open API Schema

### DIFF
--- a/application/open_api_definitions/monsternames.yaml
+++ b/application/open_api_definitions/monsternames.yaml
@@ -343,13 +343,13 @@ paths:
         "200":
           $ref: "#/components/responses/200GetFirstAndLastName"
 
-securityDefinitions:
-  api_key:
-    type: "apiKey"
-    name: "x-api-key"
-    in: "header"
-
 components:
+  securitySchemes:
+    api_key:
+      type: "apiKey"
+      name: "x-api-key"
+      in: "header"
+
   examples:
     FirstName:
       summary: Add a new first name

--- a/application/open_api_definitions/monsternames.yaml
+++ b/application/open_api_definitions/monsternames.yaml
@@ -52,9 +52,14 @@ paths:
           }
       responses:
         "200":
+          description: "Successful request"
+          content:
+            text/html:
+              schema:
+                type: string
           headers:
-            Content-Type:
-              type: string
+            "Content-Type":
+              $ref: '#/components/headers/Content-Type'
 
   /goatmen:
     post:
@@ -344,6 +349,12 @@ paths:
           $ref: "#/components/responses/200GetFirstAndLastName"
 
 components:
+  headers:
+    Content-Type:
+      schema:
+        type: string
+        description: Type of content to return
+
   securitySchemes:
     api_key:
       type: "apiKey"

--- a/application/swagger_ui/index.html
+++ b/application/swagger_ui/index.html
@@ -52,7 +52,7 @@
         layout: "StandaloneLayout",
         validatorUrl: "https://validator.swagger.io/validator",
         urls: [
-          {url: "https://raw.githubusercontent.com/sudoblark/sudoblark.monsternames.api/refs/heads/main/application/open_api_definitions/monsternames.yaml", name: "monsternames"}
+          {url: "https://raw.githubusercontent.com/sudoblark/sudoblark.monsternames.api/refs/heads/bugfix/incorrect-auth/application/open_api_definitions/monsternames.yaml", name: "monsternames"}
 
         ],
         defaultModelsExpandDepth: -1,

--- a/application/swagger_ui/index.html
+++ b/application/swagger_ui/index.html
@@ -52,7 +52,7 @@
         layout: "StandaloneLayout",
         validatorUrl: "https://validator.swagger.io/validator",
         urls: [
-          {url: "https://raw.githubusercontent.com/sudoblark/sudoblark.monsternames.api/refs/heads/bugfix/incorrect-auth/application/open_api_definitions/monsternames.yaml", name: "monsternames"}
+          {url: "https://raw.githubusercontent.com/sudoblark/sudoblark.monsternames.api/refs/heads/main/application/open_api_definitions/monsternames.yaml", name: "monsternames"}
 
         ],
         defaultModelsExpandDepth: -1,


### PR DESCRIPTION
# Description

Fix `invalid` Open API schema appearing in the SwaggerUI via:
- Properly scoping out the response type for a 200 to root `\` with `GET`
- Move security schema into `components`

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Successfully deployed, when referencing this bugfix branch, and confirmed that `invalid` no appears in the Swagger UI.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have made corresponding changes to the documentation
