### PR TITLE
chore: migrate CI/CD from static AWS keys to GitHub Actions OIDC

### DIFF
--- a/.github/workflows/apply.yaml
+++ b/.github/workflows/apply.yaml
@@ -1,15 +1,12 @@
 name: Terraform Apply
 
-env:
-  AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-  AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-
 on:
   workflow_dispatch:
 
 permissions:
   contents: read
   pull-requests: write
+  id-token: write
 
 jobs:
   apply:
@@ -27,6 +24,12 @@ jobs:
       - name: Create Lambda deployment packages
         run: |
           ./scripts/build-lambda.sh backend
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::741139166799:role/service-accounts/aws-sudoblark-management-github-cicd-role
+          aws-region: eu-west-2
 
       - name: terraform apply
         uses: dflook/terraform-apply@v1

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -5,13 +5,10 @@ on:
     branches:
       - main
 
-env:
-  AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-  AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-
 permissions:
   contents: read
   pull-requests: write
+  id-token: write
 
 jobs:
   format_check:
@@ -46,6 +43,12 @@ jobs:
       - name: Create Lambda deployment packages
         run: |
           ./scripts/build-lambda.sh backend
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::741139166799:role/service-accounts/aws-sudoblark-management-github-cicd-role
+          aws-region: eu-west-2
 
       - name: terraform validate
         uses: dflook/terraform-validate@v2
@@ -114,6 +117,12 @@ jobs:
       - name: Create Lambda deployment packages
         run: |
           ./scripts/build-lambda.sh backend
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::741139166799:role/service-accounts/aws-sudoblark-management-github-cicd-role
+          aws-region: eu-west-2
 
       - name: terraform plan
         uses: dflook/terraform-plan@v2


### PR DESCRIPTION
# Description

Migrates GitHub Actions workflows from static IAM user credentials to GitHub Actions OIDC, eliminating long-lived AWS access keys. GitHub Actions exchanges a short-lived OIDC token for temporary credentials via the management account OIDC role, which then assumes the downstream Terraform role as before.

- Remove `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` env vars from all workflows
- Add `id-token: write` permission to all jobs requiring AWS access
- Add `aws-actions/configure-aws-credentials@v4` step before each Terraform operation
- Update `assume_role` ARNs in `main.tf` to `terraform-github-cicd-role` naming convention

Part of org-wide OIDC migration. `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` secrets can be removed from this repo after merge and pipeline verification.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [x] Workflow triggered after merge and pipeline completed successfully with OIDC credentials
- [x] Terraform plan/apply used temporary credentials (no static key references in logs)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have made corresponding changes to the documentation
- [x] Terraform validate works locally
- [x] Terraform plan passes in the pipeline with an expected result